### PR TITLE
reference fields accept list

### DIFF
--- a/.github/ISSUE_TEMPLATE/submission.yml
+++ b/.github/ISSUE_TEMPLATE/submission.yml
@@ -98,35 +98,50 @@ body:
       description: Add keywords (one per line).
 
   # 6. References
-  - type: input
+  - type: textarea
     id: publication_reference
     attributes:
-      label: Publication Reference
-      description: Provide the DOI or link to a publication related to this use case (if available).
+      label: Publication References
+      description: Provide one or more DOIs or publication links, one per line (optional). The first link is highlighted on the gallery card; additional links appear in the detailed view.
+      placeholder: |
+        https://doi.org/...
+        https://example.org/publication
 
-  - type: input
+  - type: textarea
     id: repo_reference
     attributes:
-      label: Repository Reference
-      description: Provide a link to the source code repository associated with this use case (e.g., GitHub, GitLab).
+      label: Repository References
+      description: Provide one or more source repository links, one per line (e.g., GitHub, GitLab). The first link is highlighted on the gallery card; additional links appear in the detailed view.
+      placeholder: |
+        https://github.com/org/repo
+        https://gitlab.com/group/project
 
-  - type: input
-    id: nomad_resource_link
+  - type: textarea
+    id: dataset_reference
     attributes:
-      label: NOMAD Resource Link
-      description: Provide one or more links to NOMAD resources related to this use case. This can include NOMAD uploads, datasets, entries, Apps, Oasis pages, search interfaces, workflows, or DOIs hosted within NOMAD. Multiple links can be provided separated by commas. The first link will be connected to the main NOMAD icon displayed on the gallery card, while additional links will be listed in the detailed view.
+      label: Dataset References
+      description: Provide one or more NOMAD/dataset links, one per line (DOI, upload, app, or Oasis entry). The first link is highlighted on the gallery card; additional links appear in the detailed view.
+      placeholder: |
+        https://nomad-lab.eu/prod/...
+        https://doi.org/...
 
-  - type: input
+  - type: textarea
     id: funding_reference
     attributes:
-      label: Funding Reference
-      description: Grant number or agency.
+      label: Funding References
+      description: Provide funding agency and grant/project details, one per line. Example: DFG – FAIRmat (NFDI 39/1). Multiple funders can be listed on separate lines and will appear in the detailed view.
+      placeholder: |
+        DFG - Project 460197019
+        Horizon Europe - Grant 123456
 
-  - type: input
+  - type: textarea
     id: media_url
     attributes:
-      label: Media URL
-      description: Provide a link to a video, animation, or GIF illustrating the use case (optional).
+      label: Media URLs
+      description: Provide one or more media links, one per line (video, animation, GIF, presentation). The first link is highlighted on the gallery card; additional links appear in the detailed view.
+      placeholder: |
+        https://example.org/demo-video
+        https://example.org/animation.gif
 
   # 7. Metrics
   - type: input

--- a/.github/workflows/create-submission.yml
+++ b/.github/workflows/create-submission.yml
@@ -105,6 +105,11 @@ jobs:
                 .slice(0, maxItems);
             }
 
+            // Return first item from list or empty string.
+            function firstOrEmpty(values) {
+              return values && values.length > 0 ? values[0] : "";
+            }
+
             // Add YAML key only when value exists.
             function addScalarField(lines, key, value) {
               const v = cleanSingleLine(value, 1000);
@@ -144,11 +149,11 @@ jobs:
             const methodologyType = cleanSingleLine(process.env.METHODOLOGY, 80);
             const technique = cleanSingleLine(process.env.TECHNIQUE, 400);
             const dataSize = cleanSingleLine(process.env.DATA_SIZE, 100);
-            const publicationReference = cleanSingleLine(process.env.PUBLICATION_REFERENCE, 1000);
-            const repositoryReference = cleanSingleLine(process.env.REPO_REFERENCE, 1000);
-            const nomadResourceLink = cleanSingleLine(process.env.NOMAD_RESOURCE_LINK, 1000);
-            const fundingReference = cleanSingleLine(process.env.FUNDING_REFERENCE, 300);
-            const mediaUrl = cleanSingleLine(process.env.MEDIA_URL, 1000);
+            const publicationReferences = toList(process.env.PUBLICATION_REFERENCE, 30);
+            const repositoryReferences = toList(process.env.REPO_REFERENCE, 30);
+            const datasetReferences = toList(process.env.DATASET_REFERENCE, 30);
+            const fundingReferences = toList(process.env.FUNDING_REFERENCE, 30);
+            const mediaUrls = toList(process.env.MEDIA_URL, 30);
             const estimatedActiveUsers = cleanSingleLine(process.env.ESTIMATED_ACTIVE_USERS, 120);
             const downloads = cleanSingleLine(process.env.DOWNLOADS, 120);
 
@@ -175,12 +180,18 @@ jobs:
             addScalarField(lines, "technique", technique);
             addListField(lines, "coauthors", contributors);
             addScalarField(lines, "image_path", imagePathRaw);
+            addScalarField(lines, "entry_link", firstOrEmpty(datasetReferences));
             addListField(lines, "keywords", keywords);
-            addScalarField(lines, "publication_reference", publicationReference);
-            addScalarField(lines, "repository_reference", repositoryReference);
-            addScalarField(lines, "nomad_resource_link", nomadResourceLink);
-            addScalarField(lines, "funding_reference", fundingReference);
-            addScalarField(lines, "media_url", mediaUrl);
+            addScalarField(lines, "publication_reference", firstOrEmpty(publicationReferences));
+            addScalarField(lines, "repository_reference", firstOrEmpty(repositoryReferences));
+            addScalarField(lines, "dataset_reference", firstOrEmpty(datasetReferences));
+            addScalarField(lines, "funding_reference", firstOrEmpty(fundingReferences));
+            addScalarField(lines, "media_url", firstOrEmpty(mediaUrls));
+            addListField(lines, "publication_references", publicationReferences);
+            addListField(lines, "repository_references", repositoryReferences);
+            addListField(lines, "dataset_references", datasetReferences);
+            addListField(lines, "funding_references", fundingReferences);
+            addListField(lines, "media_urls", mediaUrls);
             addScalarField(lines, "data_size", dataSize);
             addScalarField(lines, "estimated_active_users", estimatedActiveUsers);
             addScalarField(lines, "downloads", downloads);

--- a/main.py
+++ b/main.py
@@ -41,6 +41,13 @@ def _read_front_matter_from_docs(file_path):
 
 def _normalize_use_case_info(data, body=""):
     """Normalize richer use-case metadata without affecting old card logic."""
+    def _to_line_list(value):
+        if isinstance(value, list):
+            return [str(v).strip() for v in value if str(v).strip()]
+        if isinstance(value, str):
+            return [line.strip() for line in value.splitlines() if line.strip()]
+        return []
+
     coauthors = data.get("coauthors", [])
     if isinstance(coauthors, str):
         coauthors = [c.strip() for c in coauthors.split(",") if c.strip()]
@@ -62,6 +69,28 @@ def _normalize_use_case_info(data, body=""):
     entry_link = (
         data.get("entry_link") or data.get("external_url") or ""
     ).strip()
+
+    publication_references = (
+        _to_line_list(data.get("publication_references"))
+        or _to_line_list(data.get("publication_reference"))
+    )
+    repository_references = (
+        _to_line_list(data.get("repository_references"))
+        or _to_line_list(data.get("repository_reference"))
+        or _to_line_list(data.get("repo_link"))
+    )
+    dataset_references = (
+        _to_line_list(data.get("dataset_references"))
+        or _to_line_list(data.get("dataset_reference"))
+    )
+    funding_references = (
+        _to_line_list(data.get("funding_references"))
+        or _to_line_list(data.get("funding_reference"))
+    )
+    media_urls = (
+        _to_line_list(data.get("media_urls"))
+        or _to_line_list(data.get("media_url"))
+    )
 
     return {
         "title": data.get("title", "Untitled Submission"),
@@ -85,17 +114,21 @@ def _normalize_use_case_info(data, body=""):
         "data_size": (data.get("data_size", "") or "").strip(),
         "active_users": data.get("estimated_active_users", None),
         "downloads": data.get("downloads", None),
-        "media_url": (data.get("media_url", "") or "").strip(),
+        "media_url": media_urls[0] if media_urls else "",
         "coauthors": coauthors,
         "keywords": keywords,
-        "publication": (data.get("publication_reference", "") or "").strip(),
-        "funding": (data.get("funding_reference", "") or "").strip(),
-        "nomad_resource_link": (data.get("nomad_resource_link", "") or "").strip(),
+        "publication": publication_references[0] if publication_references else "",
+        "publication_references": publication_references,
+        "funding": funding_references[0] if funding_references else "",
+        "funding_references": funding_references,
+        "dataset_reference": dataset_references[0] if dataset_references else "",
+        "dataset_references": dataset_references,
         "image_name": data.get("image_name", data.get("title", "Image")),
         "image_path": image_path,
-        "repo_link": repo_link,
+        "repo_link": repository_references[0] if repository_references else repo_link,
+        "repository_references": repository_references,
         "repo_name": (data.get("repo_name", "") or "").strip() or repo_link,
-        "entry_link": entry_link,
+        "entry_link": entry_link or (dataset_references[0] if dataset_references else ""),
         "entry_name": (data.get("entry_name", "") or "").strip() or entry_link,
     }
 
@@ -326,44 +359,74 @@ def _build_right_column(info, escaped):
     nomad_resource_link = escaped["nomad_resource_link"]
     funding = escaped["funding"]
     media_url = escaped["media_url"]
+    publication_references = escaped["publication_references"]
+    repository_references = escaped["repository_references"]
+    dataset_references = escaped["dataset_references"]
+    funding_references = escaped["funding_references"]
+    media_urls = escaped["media_urls"]
     col = []
     if info["publication"]:
+        publication_extra = "".join(
+            f'<li><a href="{ref}" target="_blank" rel="noopener">{ref}</a></li>'
+            for ref in publication_references[1:]
+        )
         col.append(f'''
             <div class="grid-use-case-card__detail">
               <h4>Publication Reference</h4>
               <a href="{publication}" target="_blank"
                  rel="noopener">{publication}</a>
+              {"<ul>" + publication_extra + "</ul>" if publication_extra else ""}
             </div>
             ''')
     if info["repo_link"]:
+        repository_extra = "".join(
+            f'<li><a href="{ref}" target="_blank" rel="noopener">{ref}</a></li>'
+            for ref in repository_references[1:]
+        )
         col.append(f'''
             <div class="grid-use-case-card__detail">
               <h4>Repository Reference</h4>
               <a href="{repo_link}" target="_blank"
                  rel="noopener">{repo_link}</a>
+              {"<ul>" + repository_extra + "</ul>" if repository_extra else ""}
             </div>
             ''')
-    if info["nomad_resource_link"]:
+    if info["dataset_reference"]:
+        dataset_extra = "".join(
+            f'<li><a href="{ref}" target="_blank" rel="noopener">{ref}</a></li>'
+            for ref in dataset_references[1:]
+        )
         col.append(f'''
             <div class="grid-use-case-card__detail">
               <h4>Dataset Reference</h4>
-              <a href="{nomad_resource_link}" target="_blank"
-                 rel="noopener">{nomad_resource_link}</a>
+              <a href="{dataset_reference}" target="_blank"
+                 rel="noopener">{dataset_reference}</a>
+              {"<ul>" + dataset_extra + "</ul>" if dataset_extra else ""}
             </div>
             ''')
     if info["funding"]:
+        funding_extra = "".join(
+            f"<li>{ref}</li>"
+            for ref in funding_references[1:]
+        )
         col.append(f'''
             <div class="grid-use-case-card__detail">
               <h4>Funding Reference</h4>
               <p>{funding}</p>
+              {"<ul>" + funding_extra + "</ul>" if funding_extra else ""}
             </div>
             ''')
     if info["media_url"]:
+        media_extra = "".join(
+            f'<li><a href="{ref}" target="_blank" rel="noopener">{ref}</a></li>'
+            for ref in media_urls[1:]
+        )
         col.append(f'''
             <div class="grid-use-case-card__detail">
               <h4>Media URL</h4>
               <a href="{media_url}" target="_blank"
                  rel="noopener">{media_url}</a>
+              {"<ul>" + media_extra + "</ul>" if media_extra else ""}
             </div>
             ''')
     return col
@@ -438,10 +501,15 @@ def _render_grid_use_case_card(file_path, index=0):
         )
         escaped_vals = {
             "publication": publication,
+            "publication_references": [esc(v) for v in info.get("publication_references", [])],
             "repo_link": repo_link,
-            "nomad_resource_link": nomad_resource_link,
+            "repository_references": [esc(v) for v in info.get("repository_references", [])],
+            "dataset_reference": dataset_reference,
+            "dataset_references": [esc(v) for v in info.get("dataset_references", [])],
             "funding": funding,
+            "funding_references": [esc(v) for v in info.get("funding_references", [])],
             "media_url": media_url,
+            "media_urls": [esc(v) for v in info.get("media_urls", [])],
         }
         right_column = _build_right_column(info, escaped_vals)
 


### PR DESCRIPTION
https://github.com/FAIRmat-NFDI/nomad-gallery/issues/51#issuecomment-4499687636

> For this we need to instruct the submitter that multiple links are possible separated by comma. And only the first link will be linked to the main icons on the card, while the others appear listed in the detailed view. Can you also update the main.py file to parse the links as lists under each header if more than one is submitted.
> 
> For publications: Provide one or more DOIs or links to publications related to this use case (optional). Multiple links can be provided separated by commas. The first link will be highlighted on the gallery card, while additional links will be listed in the detailed view.
> 
> For repository: Provide one or more links to source code repositories associated with this use case (e.g., GitHub, GitLab). Multiple links can be provided separated by commas. The first link will be highlighted on the gallery card, while additional links will be listed in the detailed view.
> 
> For Media links: Provide one or more links to videos, animations, GIFs, presentations, or other media illustrating this use case (optional). Multiple links can be provided separated by commas. The first link will be highlighted on the gallery card, while additional links will be listed in the detailed view.
> 
> For Funder reference: Provide the name of the funding agency and, if applicable, the associated grant number or project identifier supporting this work. Multiple funders can be provided separated by commas. Example: “DFG – FAIRmat (NFDI 39/1), Horizon Europe – Grant No. 101123456”.:

I didn't use "comma separated" values here, only "one line per item instead" as it might be more readable to user also DOI/links might contain commas