### PR TITLE
change "contributors" and "keywords" to comma separated list

### DIFF
--- a/.github/ISSUE_TEMPLATE/submission.yml
+++ b/.github/ISSUE_TEMPLATE/submission.yml
@@ -58,11 +58,12 @@ body:
       required: true
 
   # 3. Authors (Coauthors)
-  - type: textarea
+  - type: input
     id: contributors
     attributes:
       label: Contributors
-      description: List additional contributors involved in this use case or submission (one per line).
+      description: List all contributors involved in this use case using the format first name last name, separated by commas. If you, as the submitter, are also a contributor to the work, please include your name here as well.
+      placeholder: Firstname Lastname, Firstname Lastname, Firstname Lastname
 
   # 4. Methodology
   - type: dropdown
@@ -91,11 +92,12 @@ body:
       placeholder: "e.g., 50 GB"
       description: Approximate size of the dataset associated with this use case.
 
-  - type: textarea
+  - type: input
     id: keywords
     attributes:
       label: Keywords
-      description: Add keywords (one per line).
+      description: Add keywords related to this use case, separated by commas. Keywords can describe the scientific domain, methods, software, workflows, instruments, materials, FAIR aspects, or NOMAD features relevant to the submission.
+      placeholder: Perovskites, DFT, Workflow automation, NOMAD App
 
   # 6. References
   - type: textarea

--- a/.github/workflows/create-submission.yml
+++ b/.github/workflows/create-submission.yml
@@ -108,6 +108,13 @@ jobs:
             // Return first item from list or empty string.
             function firstOrEmpty(values) {
               return values && values.length > 0 ? values[0] : "";
+            // Split comma-separated input into cleaned list.
+            function toCommaList(value, maxItems = 30) {
+              return cleanSingleLine(value, 6000)
+                .split(",")
+                .map((item) => item.trim())
+                .filter(Boolean)
+                .slice(0, maxItems);
             }
 
             // Add YAML key only when value exists.
@@ -144,8 +151,8 @@ jobs:
             const country = cleanSingleLine(process.env.COUNTRY, 120);
             const description = cleanMultiline(process.env.DESCRIPTION, 10000);
             const imagePathRaw = cleanSingleLine(process.env.IMAGE_URL, 1000);
-            const contributors = toList(process.env.CONTRIBUTORS, 30);
-            const keywords = toList(process.env.KEYWORDS, 30);
+            const contributors = toCommaList(process.env.CONTRIBUTORS, 30);
+            const keywords = toCommaList(process.env.KEYWORDS, 30);
             const methodologyType = cleanSingleLine(process.env.METHODOLOGY, 80);
             const technique = cleanSingleLine(process.env.TECHNIQUE, 400);
             const dataSize = cleanSingleLine(process.env.DATA_SIZE, 100);


### PR DESCRIPTION
> Replace rich text fields with text fields to improve form visual appearance
> 
> This would apply for the following:
> 
> Contributers, Update description to: List all contributors involved in this use case using the format first name last name, separated by commas. If you, as the submitter, are also a contributor to the work, please include your name here as well.
> 
> Keywords, update description to: Add keywords related to this use case, separated by commas. Keywords can describe the scientific domain, methods, software, workflows, instruments, materials, FAIR aspects, or NOMAD features relevant to the submission.

I assume here by "rich text fields" you mean the github multi-line textarea?

I think we might need some discussion here as in https://github.com/FAIRmat-NFDI/nomad-gallery/pull/54 we separated values into different lines, not sure if we should use commas here